### PR TITLE
Corrected docs for Get-AzSecurityPricing - updated examples, descriptions, and output

### DIFF
--- a/src/Security/Security/ChangeLog.md
+++ b/src/Security/Security/ChangeLog.md
@@ -19,6 +19,10 @@
 -->
 ## Upcoming Release
 
+## Version 0.7.8
+* Updated examples Get-AzSecurityPricing
+* Updated examples Set-AzSecurityPricing
+
 ## Version 0.7.7
 * Update references in .psd1 to use relative path
 

--- a/src/Security/Security/help/Get-AzSecurityPricing.md
+++ b/src/Security/Security/help/Get-AzSecurityPricing.md
@@ -29,35 +29,45 @@ Get-AzSecurityPricing -ResourceId <String> [-DefaultProfile <IAzureContextContai
 
 ## DESCRIPTION
 Azure Security Center pricing tier is decided per scope, with this cmdlet you can get the configured pricing tiers.
-Subscription pricing tier include all the resource groups under it.
-Resource Group pricing tier will override the subscription pricing tier.
 
 ## EXAMPLES
 
 ### Example 1
 ```powershell
 PS C:\> Get-AzSecurityPricing
-Id--/subscriptions/fbaa2b23-e9dd-4bed-93c1-9e2a44f64bc0/providers/Microsoft.Security/pricings/VirtualMachines
-/subscriptions/fbaa2b23-e9dd-4bed-93c1-9e2a44f64bc0/providers/Microsoft.Security/pricings/SqlServers
-/subscriptions/fbaa2b23-e9dd-4bed-93c1-9e2a44f64bc0/providers/Microsoft.Security/pricings/AppServices
-/subscriptions/fbaa2b23-e9dd-4bed-93c1-9e2a44f64bc0/providers/Microsoft.Security/pricings/StorageAccounts
-/subscriptions/fbaa2b23-e9dd-4bed-93c1-9e2a44f64bc0/providers/Microsoft.Security/pricings/SqlServerVirtualMachin…
-/subscriptions/fbaa2b23-e9dd-4bed-93c1-9e2a44f64bc0/providers/Microsoft.Security/pricings/KubernetesService
-/subscriptions/fbaa2b23-e9dd-4bed-93c1-9e2a44f64bc0/providers/Microsoft.Security/pricings/ContainerRegistry
-/subscriptions/fbaa2b23-e9dd-4bed-93c1-9e2a44f64bc0/providers/Microsoft.Security/pricings/KeyVaults
+Id                                                                                                                   Name                      PricingTier    FreeTrialRemainingTime
+--                                                                                                                   ----                      -----------    ----------------------
+/subscriptions/fbaa2b23-e9dd-4bed-93c1-9e2a44f64bc0/providers/Microsoft.Security/pricings/VirtualMachines            VirtualMachines           Free           00:00:00
+/subscriptions/fbaa2b23-e9dd-4bed-93c1-9e2a44f64bc0/providers/Microsoft.Security/pricings/Sqlservers                 SqlServers                Standard       00:00:00
+/subscriptions/fbaa2b23-e9dd-4bed-93c1-9e2a44f64bc0/providers/Microsoft.Security/pricings/AppServices                AppServices               Free           00:00:00
+/subscriptions/fbaa2b23-e9dd-4bed-93c1-9e2a44f64bc0/providers/Microsoft.Security/pricings/StorageAccounts            StorageAccounts           Free           00:00:00
+/subscriptions/fbaa2b23-e9dd-4bed-93c1-9e2a44f64bc0/providers/Microsoft.Security/pricings/SqlserverVirtualMachines   SqlservervirtualMachines  Free           00:00:00
+/subscriptions/fbaa2b23-e9dd-4bed-93c1-9e2a44f64bc0/providers/Microsoft.Security/pricings/KubernetesService          KubernetesService         Free           00:00:00
+/subscriptions/fbaa2b23-e9dd-4bed-93c1-9e2a44f64bc0/providers/Microsoft.Security/pricings/ContainerRegistry          ContainerRegistry         Free           00:00:00
+/subscriptions/fbaa2b23-e9dd-4bed-93c1-9e2a44f64bc0/providers/Microsoft.Security/pricings/KeyVaults                  KeyVaults                 Free           00:00:00
 ```
 
-Gets all the configured pricing tiers for the subscription and the resource groups under it.
+Gets all the configured pricing tiers for the subscription.
+
+
 
 ### Example 2
 ```powershell
-PS C:\> Get-AzSecurityPricing -ResourceGroupName "myService1"
-Id                                                                                                                             Name       PricingTier
---                                                                                                                             ----       -----------
-/subscriptions/487bb485-b5b0-471e-9c0d-10717612f869/resourceGroups/myService1/providers/Microsoft.Security/pricings/myService1 myService1 Standard
+PS C:\> Get-AzSecurityPricing -ResourceId
 ```
 
-Gets the configured pricing tier for the "myService1" resource group.
+Gets pricing details of the specific ID. Where ResourceId is one of IDs from example 1.
+
+### Example 3
+```powershell
+PS C:\> Get-AzSecurityPricing -Name
+```
+
+Gets pricing details of the named Azure Defender plan. Where name is one of the names from example 1.
+
+
+, and Name is one of 8 above as well.
+
 
 ## PARAMETERS
 

--- a/src/Security/Security/help/Get-AzSecurityPricing.md
+++ b/src/Security/Security/help/Get-AzSecurityPricing.md
@@ -37,10 +37,14 @@ Resource Group pricing tier will override the subscription pricing tier.
 ### Example 1
 ```powershell
 PS C:\> Get-AzSecurityPricing
-Id                                                                                                                             Name       PricingTier
---                                                                                                                             ----       -----------
-/subscriptions/487bb485-b5b0-471e-9c0d-10717612f869/providers/Microsoft.Security/pricings/default                              default    Standard
-/subscriptions/487bb485-b5b0-471e-9c0d-10717612f869/resourceGroups/myService1/providers/Microsoft.Security/pricings/myService1 myService1 Standard
+Id--/subscriptions/fbaa2b23-e9dd-4bed-93c1-9e2a44f64bc0/providers/Microsoft.Security/pricings/VirtualMachines
+/subscriptions/fbaa2b23-e9dd-4bed-93c1-9e2a44f64bc0/providers/Microsoft.Security/pricings/SqlServers
+/subscriptions/fbaa2b23-e9dd-4bed-93c1-9e2a44f64bc0/providers/Microsoft.Security/pricings/AppServices
+/subscriptions/fbaa2b23-e9dd-4bed-93c1-9e2a44f64bc0/providers/Microsoft.Security/pricings/StorageAccounts
+/subscriptions/fbaa2b23-e9dd-4bed-93c1-9e2a44f64bc0/providers/Microsoft.Security/pricings/SqlServerVirtualMachin…
+/subscriptions/fbaa2b23-e9dd-4bed-93c1-9e2a44f64bc0/providers/Microsoft.Security/pricings/KubernetesService
+/subscriptions/fbaa2b23-e9dd-4bed-93c1-9e2a44f64bc0/providers/Microsoft.Security/pricings/ContainerRegistry
+/subscriptions/fbaa2b23-e9dd-4bed-93c1-9e2a44f64bc0/providers/Microsoft.Security/pricings/KeyVaults
 ```
 
 Gets all the configured pricing tiers for the subscription and the resource groups under it.

--- a/src/Security/Security/help/Set-AzSecurityPricing.md
+++ b/src/Security/Security/help/Set-AzSecurityPricing.md
@@ -31,24 +31,11 @@ Sets the pricing of Azure Security Center tier for a scope.
 
 ### Example 1
 ```powershell
-PS C:\> Set-AzSecurityPricing -Name "default" -PricingTier "Standard"
-Id                                                                                                 Name    PricingTier
---                                                                                                 ----    -----------
-/subscriptions/487bb485-b5b0-471e-9c0d-10717612f869/providers/Microsoft.Security/pricings/default default Standard
+PS C:\> Set-AzSecurityPricing -Name "virtualmachines" -PricingTier "Free"
 ```
 
 Sets the subscription Azure Security Center pricing tier to "Standard"
 
-### Example 2
-```powershell
-PS C:\> Set-AzSecurityPricing -Name "myService1" -ResourceGroupName "myService1" -PricingTier "Standard"
-
-Id                                                                                                                     
---                                                                                                                     
-/subscriptions/487bb485-b5b0-471e-9c0d-10717612f869/resourceGroups/myService1/providers/Microsoft.Security/pricings/...
-```
-
-Sets the "myService1" resource group Azure Security Center pricing tier to "Standard"
 
 ## PARAMETERS
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Updated the docs for Get-AzSecurityPricing to reflect the current behaviour of this API. The API no longer works with resource groups. And the examples were wrong.
THIS IS ONLY A DOC CHANGE - the API was changed 6 months ago.

## Checklist

- [X] I have read the [_Submitting Changes_](../blob/master/CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](../blob/master/CONTRIBUTING.md)
- [X] The title of the PR is clear and informative
- [] The appropriate `ChangeLog.md` file(s) has been updated:
    - For any service, the `ChangeLog.md` file can be found at `src/{{SERVICE}}/{{SERVICE}}/ChangeLog.md`
    - A snippet outlining the change(s) made in the PR should be written under the `## Upcoming Release` header -- no new version header should be added
- [X] The PR does not introduce [breaking changes](../blob/master/documentation/breaking-changes/breaking-changes-definition.md)
- [X] If applicable, the changes made in the PR have proper test coverage
- [ ] For public API changes to cmdlets:
    - [ ] a cmdlet design review was approved for the changes in [this repository](https://github.com/Azure/azure-powershell-cmdlet-review-pr) (_Microsoft internal only_)
    - [ ] the markdown help files have been regenerated using the commands listed [here](../blob/master/documentation/development-docs/help-generation.md#updating-all-markdown-files-in-a-module)

