### PR TITLE
Fix PartnerServerName check in GetAzureSqlDatabaseReplicationLink.cs to check by key instead of value

### DIFF
--- a/src/Sql/Sql/ChangeLog.md
+++ b/src/Sql/Sql/ChangeLog.md
@@ -18,6 +18,7 @@
         - Additional information about change #1
 -->
 ## Upcoming Release
+* Fixed a bug in GetAzureSqlDatabaseReplicationLink.cs where PartnerServerName parameter was being checked for by value instead of key
 
 ## Version 2.1.2
 * Fix vulnerability assessment set baseline cmdlets functionality to work on master db for azure database and limit it on managed instance system databases.

--- a/src/Sql/Sql/Replication/Cmdlet/GetAzureSqlDatabaseReplicationLink.cs
+++ b/src/Sql/Sql/Replication/Cmdlet/GetAzureSqlDatabaseReplicationLink.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.Commands.Sql.Replication.Cmdlet
         {
             ICollection<AzureReplicationLinkModel> results;
 
-            if (MyInvocation.BoundParameters.ContainsKey(PartnerServerName) && !WildcardPattern.ContainsWildcardCharacters(PartnerServerName))
+            if (MyInvocation.BoundParameters.ContainsKey("PartnerServerName") && !WildcardPattern.ContainsWildcardCharacters(PartnerServerName))
             {
                 results = new List<AzureReplicationLinkModel>();
                 results.Add(ModelAdapter.GetLink(this.ResourceGroupName, this.ServerName, this.DatabaseName, this.PartnerResourceGroupName, this.PartnerServerName));


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

PartnerServerName (an optional parameter) is currently checking invocation by examining the value of the variable PartnerServerName instead of string literal "PartnerServerName". When invoking the cmdlet, it yields unexpected behavior as check never passes and it invokes as if PartnerServerName parameter was not passed.

Added double quotes around PartnerServerName to check for key.

## Checklist

- [x] I have read the [_Submitting Changes_](../blob/master/CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](../blob/master/CONTRIBUTING.md)
- [x] The title of the PR is clear and informative
- [x] The appropriate `ChangeLog.md` file(s) has been updated:
    - For any service, the `ChangeLog.md` file can be found at `src/{{SERVICE}}/{{SERVICE}}/ChangeLog.md`
    - A snippet outlining the change(s) made in the PR should be written under the `## Upcoming Release` header -- no new version header should be added
- [x] The PR does not introduce [breaking changes](../blob/master/documentation/breaking-changes/breaking-changes-definition.md)
- [x] If applicable, the changes made in the PR have proper test coverage
- [x] For public API changes to cmdlets:
    - [x] a cmdlet design review was approved for the changes in [this repository](https://github.com/Azure/azure-powershell-cmdlet-review-pr) (_Microsoft internal only_)
    - [x] the markdown help files have been regenerated using the commands listed [here](../blob/master/documentation/development-docs/help-generation.md#updating-all-markdown-files-in-a-module)
